### PR TITLE
Update to_regtype docs regarding error condition

### DIFF
--- a/doc/src/sgml/func.sgml
+++ b/doc/src/sgml/func.sgml
@@ -25460,11 +25460,12 @@ SELECT collation for ('foo' COLLATE "de_DE");
         <returnvalue>regtype</returnvalue>
        </para>
        <para>
-        Translates a textual type name to its OID.  A similar result is
+        Parses a string of text, extracts a potential type name from it, and
+        translates that name into an OID. A similar result is
         obtained by casting the string to type <type>regtype</type> (see
-        <xref linkend="datatype-oid"/>); however, this function will return
-        <literal>NULL</literal> rather than throwing an error if the name is
-        not found.
+        <xref linkend="datatype-oid"/>). Failure to extract a valid potential
+        type name results in an error; however, if the extracted name is not
+        known to the system, this function will return <literal>NULL</literal>.
        </para></entry>
       </row>
      </tbody>


### PR DESCRIPTION
The statement that `to_regtype` returns `NULL` rather than raising an error turns out to be false when the parser cannot extract a type. This can happen for inputs such as `inteval second`, where the SQL grammar parser fails to parse the type name. In most cases it does return `NULL` and ideally it always would for such unknown types, but sadly the overhead of handling errors thrown by the grammar is too high at this point. So document the variation, instead.